### PR TITLE
Potential fix for code scanning alert no. 8: Replacement of a substring with itself

### DIFF
--- a/frontend/src/services/artistImageService.js
+++ b/frontend/src/services/artistImageService.js
@@ -17,8 +17,7 @@ export const getArtistImage = async (artistName) => {
     if (data.results?.length > 0) {
       // iTunes gives 30x30 — replace with 200x200
       const img = data.results[0].artworkUrl30
-        ?.replace('30x30', '200x200')
-        ?.replace('bb.jpg', 'bb.jpg');
+        ?.replace('30x30', '200x200');
 
       cache[artistName] = img || null;
       return img || null;


### PR DESCRIPTION
Potential fix for [https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/8](https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/8)

In general, fix this class of issue by either:
- correcting the replacement target/replacement text to the intended values, or
- removing the replacement entirely if it is unnecessary/no-op.

For this specific code, we should remove the `.replace('bb.jpg', 'bb.jpg')` call in `frontend/src/services/artistImageService.js` (lines 19–21 region). This is the safest single fix that does not change current functionality, because the call currently does nothing.

No imports, new methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
