### PR TITLE
Potential fix for code scanning alert no. 7: Clear text storage of sensitive information

### DIFF
--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -23,10 +23,7 @@ export const signInWithGoogle = async () => {
   const token = await user.getIdToken();
   localStorage.setItem('auxless_jwt', token);
 
-  // save refresh token locally too
-  if (refreshToken) {
-    localStorage.setItem('auxless_refresh_token', refreshToken);
-  }
+  // Do not persist refresh tokens in browser storage.
 
   // check if user already exists in YOUR Firestore
   const userRef = doc(db, 'users', user.uid);
@@ -68,7 +65,7 @@ export const signInWithGoogle = async () => {
 
 // ── Save onboarding prefs + refresh token to both Firestores ──
 export const saveUserPrefs = async (uid, genres, artists) => {
-  const refreshToken = localStorage.getItem('auxless_refresh_token') || '';
+  const refreshToken = '';
 
   // 1. Save to YOUR Firestore — users collection
   await setDoc(
@@ -102,7 +99,6 @@ export const saveUserPrefs = async (uid, genres, artists) => {
 export const logoutUser = async () => {
   await signOut(auth);
   localStorage.removeItem('auxless_jwt');
-  localStorage.removeItem('auxless_refresh_token');
 };
 
 // ── Auth state listener ───────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/7](https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/7)

General fix: do not persist refresh tokens in `localStorage` (or any browser-accessible cleartext storage). Keep them in memory only for immediate use, or preferably handle refresh-token lifecycle server-side.

Best fix here without changing broader architecture: remove all client-side persistence/removal of `auxless_refresh_token`, and in `saveUserPrefs` stop reading token from `localStorage`. Since this function currently only accepts `(uid, genres, artists)`, set `refreshToken` to an empty string locally so behavior remains stable and code compiles without changing call sites. (A follow-up refactor can pass token in-memory or move token writes fully backend-side.)

Changes needed in `frontend/src/services/auth.js`:
- In `signInWithGoogle`, delete the `localStorage.setItem('auxless_refresh_token', refreshToken)` block.
- In `saveUserPrefs`, replace `localStorage.getItem('auxless_refresh_token')` with a non-persistent value (`''`).
- In `logoutUser`, remove `localStorage.removeItem('auxless_refresh_token')`.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
