### PR TITLE
Potential fix for code scanning alert no. 12: Clear text storage of sensitive information

### DIFF
--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -26,9 +26,7 @@ export const signInWithGoogle = async () => {
   const token = await user.getIdToken();
   localStorage.setItem('auxless_jwt', token);
 
-  if (refreshToken) {
-    localStorage.setItem('auxless_refresh_token', refreshToken);
-  }
+  // Do not store OAuth refresh tokens in client-side localStorage.
 
   const userRef = doc(db, 'users', user.uid);
   const snap    = await getDoc(userRef);


### PR DESCRIPTION
Potential fix for [https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/12](https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/12)

General fix: do not persist OAuth refresh tokens in cleartext on the client. Prefer keeping them server-side only, and if the frontend must keep auth state, store non-sensitive/session-scoped data only.

Best minimal fix without changing overall app flow: remove the `localStorage` write of `refreshToken` at line 30 while keeping existing token handling and backend writes unchanged. This directly eliminates the flagged sink and preserves current sign-in behavior as much as possible from this snippet.

In `frontend/src/services/auth.js`, update the `if (refreshToken)` block around lines 29–31 so it no longer calls `localStorage.setItem('auxless_refresh_token', refreshToken);`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
