### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/backend/pipelines/api/server.py
+++ b/backend/pipelines/api/server.py
@@ -281,10 +281,10 @@ def monitoring_health():
             "timestamp": time.time(),
         }), 200
     except Exception as e:
-        log.error(f"Health check failed: {e}")
+        log.error("Health check failed", exc_info=True)
         return jsonify({
             "status":    "unhealthy",
-            "error":     str(e),
+            "error":     "Internal server error",
             "timestamp": time.time(),
         }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/13](https://github.com/pvvishwesh-lang/AuxLess/security/code-scanning/13)

To fix this, keep detailed exception data in server logs and return a sanitized, generic error payload to clients.

Best single change (no functionality change beyond hardening): in `backend/pipelines/api/server.py`, within `monitoring_health()`’s `except` block (around lines 283–289), keep logging with `exc_info=True` for internal debugging, but remove `str(e)` from the JSON response and replace it with a generic message such as `"Internal server error"`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
